### PR TITLE
Allow replacing vanilla entities with BounceHelper equivalents

### DIFF
--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -1,0 +1,14 @@
+BounceHelper_ReplaceVanillaEntities_Hint=
+    Replaces vanilla entities with BounceHelper equivalents.
+
+BounceHelper_ReplaceBumpers_Hint=
+    BounceHelper bumpers do not support nodes.
+
+BounceHelper_ReplaceJellyfish_Hint=
+    BounceHelper jellyfish will always have 1 dash.
+
+BounceHelper_SoulboundJellyfish_Hint=
+    Whether the player should die if a BounceHelper jellyfish dies.
+
+BounceHelper_ReplaceMoveBlocks_Hint=
+    BounceHelper move blocks do not support steering.

--- a/Source/BounceHelperModule.cs
+++ b/Source/BounceHelperModule.cs
@@ -106,6 +106,10 @@ namespace Celeste.Mod.BounceHelper
             On.Celeste.Level.Begin += onLevelBegin;
             Everest.Events.CustomBirdTutorial.OnParseCommand += CustomBirdTutorial_OnParseCommand;
             #endregion
+
+            #region Replace vanilla entities with BounceHelper equivalents
+            Everest.Events.Level.OnLoadEntity += ReplaceVanillaEntities;
+            #endregion
         }
 
         public override void Unload()
@@ -152,6 +156,10 @@ namespace Celeste.Mod.BounceHelper
             On.Celeste.Player.DashBegin -= modDashBegin;
             On.Celeste.Level.Begin -= onLevelBegin;
             Everest.Events.CustomBirdTutorial.OnParseCommand -= CustomBirdTutorial_OnParseCommand;
+            #endregion
+
+            #region Replace vanilla entities with BounceHelper equivalents
+            Everest.Events.Level.OnLoadEntity -= ReplaceVanillaEntities;
             #endregion
         }
 
@@ -1255,6 +1263,146 @@ namespace Celeste.Mod.BounceHelper
         {
             Logger.Log("Bounce Helper", str);
         }
+        #endregion
+
+        #region Replace vanilla entities with BounceHelper equivalents
+
+        // look for vanilla entities and replace them, converting properties if necessary
+        private static bool ReplaceVanillaEntities(Level level, LevelData levelData, Vector2 offset, EntityData origEntityData)
+        {
+            BounceHelperEverywhereSettings settings = Settings.ReplaceVanillaEntities;
+
+            // only clone the EntityData if necessary
+            EntityData entityData;
+
+            if (settings.ReplaceBumpers && origEntityData.Name == "bigSpinner")
+            {
+                entityData = CloneEntityData(origEntityData);
+
+                Logger.Debug(nameof(BounceHelperModule),
+                    $"Replacing {nameof(Bumper)} at {entityData.Position + offset} with BounceHelper equivalent.");
+
+                // TODO: BounceBumpers don't support nodes
+                entityData.Name = "BounceHelper/BounceBumper";
+                level.Add(new BounceBumper(entityData, offset));
+                return true;
+            }
+            if (settings.ReplaceDreamBlocks && origEntityData.Name == "dreamBlock")
+            {
+                entityData = CloneEntityData(origEntityData);
+
+                Logger.Debug(nameof(BounceHelperModule),
+                    $"Replacing {nameof(DreamBlock)} at {entityData.Position + offset} with BounceHelper equivalent.");
+
+                entityData.Name = "BounceHelper/BounceDreamBlock";
+                if (entityData.FirstNodeNullable() is { } swingNode)
+                {
+                    // vanilla calculates half of the period, meanwhile oscillationDuration wants the full period
+                    // hence the division by 6f instead of 12f
+                    float oscillationDuration = Vector2.Distance(entityData.Position, swingNode) / 6f;
+                    if (entityData.Bool("fastMoving"))
+                        oscillationDuration /= 3f;
+
+                    entityData.Values["oscillationDuration"] = oscillationDuration;
+                }
+
+                level.Add(new BounceDreamBlock(entityData, offset));
+                return true;
+            }
+            if (settings.ReplaceFallingBlocks && origEntityData.Name == "fallingBlock")
+            {
+                entityData = CloneEntityData(origEntityData);
+
+                Logger.Debug(nameof(BounceHelperModule),
+                    $"Replacing {nameof(FallingBlock)} at {entityData.Position + offset} with BounceHelper equivalent.");
+
+                entityData.Name = "BounceHelper/BounceFallingBlock";
+                level.Add(new BounceFallingBlock(entityData, offset));
+                return true;
+            }
+            if (settings.ReplaceJellyfish && origEntityData.Name == "glider")
+            {
+                entityData = CloneEntityData(origEntityData);
+
+                Logger.Debug(nameof(BounceHelperModule),
+                    $"Replacing {nameof(Glider)} at {entityData.Position + offset} with BounceHelper equivalent.");
+
+                entityData.Name = "BounceHelper/BounceJellyfish";
+                entityData.Values["platform"] = entityData.Values["bubble"];
+                entityData.Values["soulBound"] = settings.SoulboundJellyfish;
+                level.Add(new BounceJellyfish(entityData, offset));
+                return true;
+            }
+            if (settings.ReplaceMoveBlocks && origEntityData.Name == "moveBlock")
+            {
+                entityData = CloneEntityData(origEntityData);
+
+                Logger.Debug(nameof(BounceHelperModule),
+                    $"Replacing {nameof(MoveBlock)} at {entityData.Position + offset} with BounceHelper equivalent.");
+
+                // TODO: BounceMoveBlocks don't support steering
+                // TODO: BounceMoveBlocks reform after 1s, instead of vanilla's 2.2s
+                entityData.Name = "BounceHelper/BounceMoveBlock";
+                entityData.Values["speed"] = entityData.Bool("fast") ? 75 : 60;
+                level.Add(new BounceMoveBlock(entityData, offset));
+                return true;
+            }
+            if (settings.ReplaceRefills && origEntityData.Name == "refill")
+            {
+                entityData = CloneEntityData(origEntityData);
+
+                Logger.Debug(nameof(BounceHelperModule),
+                    $"Replacing {nameof(Refill)} at {entityData.Position + offset} with BounceHelper equivalent.");
+
+                entityData.Name = "BounceHelper/BounceRefill";
+                level.Add(new BounceRefill(entityData, offset));
+                return true;
+            }
+            if (settings.ReplaceSwapBlocks && origEntityData.Name == "swapBlock")
+            {
+                entityData = CloneEntityData(origEntityData);
+
+                Logger.Debug(nameof(BounceHelperModule),
+                    $"Replacing {nameof(SwapBlock)} at {entityData.Position + offset} with BounceHelper equivalent.");
+
+                entityData.Name = "BounceHelper/BounceSwapBlock";
+                entityData.Values["moon"] = entityData.Enum<SwapBlock.Themes>("theme") == SwapBlock.Themes.Moon;
+                level.Add(new BounceSwapBlock(entityData, offset));
+                return true;
+            }
+            if (settings.ReplaceZipMovers && origEntityData.Name == "zipMover")
+            {
+                entityData = CloneEntityData(origEntityData);
+
+                Logger.Debug(nameof(BounceHelperModule),
+                    $"Replacing {nameof(ZipMover)} at {entityData.Position + offset} with BounceHelper equivalent.");
+
+                entityData.Name = "BounceHelper/BounceZipMover";
+                entityData.Values["moon"] = entityData.Enum<ZipMover.Themes>("theme") == ZipMover.Themes.Moon;
+                level.Add(new BounceZipMover(entityData, offset));
+                return true;
+            }
+
+            return false;
+        }
+
+        // create an empty Values dict and reuse it instead of making a new one every time
+        private static readonly Dictionary<string, object> EmptyValues = [];
+
+        // mutating EntityDatas is bad, because changes persist until the map is reloaded
+        // so we clone it instead
+        private static EntityData CloneEntityData(EntityData entityData) => new() {
+            ID = entityData.ID,
+            Height = entityData.Height,
+            Level = entityData.Level,
+            Name = entityData.Name,
+            Nodes = [..entityData.Nodes], // this syntax requires the .net 8 sdk to build
+            Origin = entityData.Origin,
+            Position = entityData.Position,
+            Values = new Dictionary<string, object>(entityData.Values ?? EmptyValues), // apparently Values can be null
+            Width = entityData.Width,
+        };
+
         #endregion
     }
 }

--- a/Source/BounceHelperModuleSettings.cs
+++ b/Source/BounceHelperModuleSettings.cs
@@ -6,5 +6,34 @@ namespace Celeste.Mod.BounceHelper {
         public ButtonBinding JellyfishDash { get; set; } = new ButtonBinding(Buttons.LeftShoulder, Keys.Space);
 
         public bool ForceBounceMode { get; set; }
+
+        [SettingSubText($"BounceHelper_{nameof(ReplaceVanillaEntities)}_Hint")]
+        public BounceHelperEverywhereSettings ReplaceVanillaEntities { get; set; } = new BounceHelperEverywhereSettings();
+    }
+
+    [SettingSubMenu]
+    public class BounceHelperEverywhereSettings
+    {
+        [SettingSubText($"BounceHelper_{nameof(ReplaceBumpers)}_Hint")]
+        public bool ReplaceBumpers { get; set; }
+
+        public bool ReplaceDreamBlocks { get; set; }
+
+        public bool ReplaceFallingBlocks { get; set; }
+
+        [SettingSubText($"BounceHelper_{nameof(ReplaceJellyfish)}_Hint")]
+        public bool ReplaceJellyfish { get; set; }
+
+        [SettingSubText($"BounceHelper_{nameof(SoulboundJellyfish)}_Hint")]
+        public bool SoulboundJellyfish { get; set; }
+
+        [SettingSubText($"BounceHelper_{nameof(ReplaceMoveBlocks)}_Hint")]
+        public bool ReplaceMoveBlocks { get; set; }
+
+        public bool ReplaceRefills { get; set; }
+
+        public bool ReplaceSwapBlocks { get; set; }
+
+        public bool ReplaceZipMovers { get; set; }
     }
 }


### PR DESCRIPTION
Adds settings which allow the player to replace vanilla entities with BounceHelper equivalents. Useful when playing through vanilla maps with Force Bounce Mode enabled.

> [!NOTE]
> BounceHelper entities have some key differences with vanilla ones:
> - `BounceBumper` does not support nodes, and does not wobble. This is most prominent in 6A.
> - `BounceMoveBlock` does not support steering. Additionally, it respawns after `1` second instead of vanilla's `2.2` seconds.
> - `BounceJellyfish` does not show the tutorial popup. This is however extremely minor.

Those differences are explained to the user when the appropriate setting is hovered over. 